### PR TITLE
Added support for basic preprocessors

### DIFF
--- a/Compiler.php
+++ b/Compiler.php
@@ -272,17 +272,32 @@ class Compiler
             'filters'                 => [
                 'plain' => 'Tale\\Jade\\Filter::filterPlain',
                 'css'   => 'Tale\\Jade\\Filter::filterStyle',
+                'style' => 'Tale\\Jade\\Filter::filterStyle',
                 'js'    => 'Tale\\Jade\\Filter::filterScript',
+                'script' => 'Tale\\Jade\\Filter::filterScript',
                 'php'   => 'Tale\\Jade\\Filter::filterCode',
-                //'markdown' => 'Tale\\Jade\\Filter::filterMarkdown'
+                'code' => 'Tale\\Jade\\Filter::filterCode',
+                'markdown' => 'Tale\\Jade\\Filter::filterMarkdown',
+                'md' => 'Tale\\Jade\\Filter::filterMarkdown',
+                'coffee-script' => 'Tale\\Jade\\Filter::filterCoffeeScript',
+                'coffee' => 'Tale\\Jade\\Filter::filterCoffeeScript',
+                'less' => 'Tale\\Jade\\Filter::filterLess',
+                'stylus' => 'Tale\\Jade\\Filter::filterStylus',
+                'styl' => 'Tale\\Jade\\Filter::filterStylus',
+                'sass' => 'Tale\\Jade\\Filter::filterSass'
                 //What else?
             ],
             'filterMap'               => [
+                'jade' => 'plain',
                 'css'  => 'css',
                 'js'   => 'js',
                 'php'  => 'php',
                 'md'   => 'markdown',
-                'jade' => 'plain'
+                'coffee' => 'coffee-script',
+                'less' => 'less',
+                'styl' => 'stylus',
+                'sass' => 'sass',
+                'scss' => 'sass'
             ],
             'escapeSequences'         => [
                 '\n' => "\n",

--- a/Filter.php
+++ b/Filter.php
@@ -41,6 +41,11 @@ use Tale\Jade\Parser\Node;
  * :js      => Converts to <script></script>
  * :css     => Converts to <style></style>
  * :php     => converts to <?php ? >
+ * :markdown => converts to markdown-HTML
+ * :coffee  => converts to CoffeeScript-JavaScript
+ * :less    => converts to LESS CSS
+ * :stylus  => converts to Stylus CSS
+ * :sass    => converts to SASS CSS
  *
  * @category   Presentation
  * @package    Tale\Jade
@@ -176,5 +181,134 @@ class Filter
     {
 
         return self::wrapCode($node, $indent, $newLine);
+    }
+
+    /**
+     * Compiles the markdown content to HTML.
+     *
+     * @param Node   $node    the node to be compiled
+     * @param string $indent  the indentation to use on each child
+     * @param string $newLine the new-line to append after each line
+     *
+     * @return string the wrapped HTML-string
+     * @throws Compiler\Exception when the Parsedown package is not installed
+     */
+    public static function filterMarkdown(Node $node, $indent, $newLine)
+    {
+
+        if (!class_exists('Parsedown'))
+            throw new Compiler\Exception(
+                "Failed to compile Markdown: "
+                ."Please install the erusev/parsedown composer package"
+            );
+
+        $parsedown = new \Parsedown();
+
+        return $parsedown->text($node->text());
+    }
+
+
+    /**
+     * Compiles the CoffeeScript content to JavaScript
+     *
+     * @param Node   $node    the node to be compiled
+     * @param string $indent  the indentation to use on each child
+     * @param string $newLine the new-line to append after each line
+     *
+     * @return string the wrapped JavaScript-HTML-string
+     * @throws Compiler\Exception when the CoffeeScript package is not installed
+     */
+    public static function filterCoffeeScript(Node $node, $indent, $newLine)
+    {
+
+        if (!class_exists('CoffeeScript\\Compiler'))
+            throw new Compiler\Exception(
+                "Failed to compile CoffeeScript: "
+                ."Please install the coffeescript/coffeescript composer package"
+            );
+
+        var_dump($node->text());
+
+        $js = \CoffeeScript\Compiler::compile($node->text(), [
+            'header' => '',
+            'filename' => 'Imported-at-('.$node->line.':'.$node->offset.').coffee'
+        ]);
+
+        return '<script>'.$newLine.$indent.$js.$newLine.$indent.'</script>';
+    }
+
+    /**
+     * Compiles the LESS content to CSS
+     *
+     * @param Node   $node    the node to be compiled
+     * @param string $indent  the indentation to use on each child
+     * @param string $newLine the new-line to append after each line
+     *
+     * @return string the wrapped Less-CSS-string
+     * @throws Compiler\Exception when the LESS package is not installed
+     */
+    public static function filterLess(Node $node, $indent, $newLine)
+    {
+
+        if (!class_exists('lessc'))
+            throw new Compiler\Exception(
+                "Failed to compile LESS: "
+                ."Please install the leafo/lessphp composer package"
+            );
+
+        $less = new \lessc;
+        $css = $less->compile($node->text());
+
+        return '<style>'.$newLine.$indent.$css.$newLine.$indent.'</style>';
+    }
+
+    /**
+     * Compiles the Stylus content to CSS
+     *
+     * @param Node   $node    the node to be compiled
+     * @param string $indent  the indentation to use on each child
+     * @param string $newLine the new-line to append after each line
+     *
+     * @return string the wrapped Stylus-CSS-string
+     * @throws Compiler\Exception when the Stylus package is not installed
+     */
+    public static function filterStylus(Node $node, $indent, $newLine)
+    {
+
+        if (!class_exists('Stylus\\Stylus'))
+            throw new Compiler\Exception(
+                "Failed to compile Stylus: "
+                ."Please install the neemzy/stylus composer package"
+            );
+
+        $stylus = new \Stylus\Stylus;
+        $css = $stylus->fromString($node->text())->toString();
+
+        return '<style>'.$newLine.$indent.$css.$newLine.$indent.'</style>';
+    }
+
+    /**
+     * Compiles the SASS content to CSS
+     *
+     * @param Node   $node    the node to be compiled
+     * @param string $indent  the indentation to use on each child
+     * @param string $newLine the new-line to append after each line
+     *
+     * @return string the wrapped SASS-CSS-string
+     * @throws Compiler\Exception when the Stylus package is not installed
+     */
+    public static function filterSass(Node $node, $indent, $newLine)
+    {
+
+        if (!class_exists('Leafo\\ScssPhp\\Compiler'))
+            throw new Compiler\Exception(
+                "Failed to compile SASS: "
+                ."Please install the leafo/scssphp composer package"
+            );
+
+        $sass = new \Leafo\ScssPhp\Compiler;
+        $css = $sass->compile($node->text());
+
+        return '<style>'.$newLine.$indent.$css.$newLine.$indent.'</style>';
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,12 @@
         "files": [
             "functions.php"
         ]
+    },
+    "suggest": {
+        "erusev/parsedown": "Enables Markdown filtering",
+        "coffeescript/coffeescript": "Enables CoffeeScript filtering",
+        "leafo/lessphp": "Enables LESS filtering",
+        "neemzy/stylus": "Enables Stylus filtering",
+        "leafo/scssphp": "Enables SASS filtering"
     }
 }


### PR DESCRIPTION
Added optional support for the following preprocessors:
Markdown via the erusev/parsedown package
CoffeeScript via the coffeescript/coffeescript package
LESS via the leafo/lessphp package
Stylus via the neemzy/stylus package
SASS/SCSS via the leafo/scssphp package

Make sure to install the (optional) packages before you use them
