### PR TITLE
Add is_object check to build_value function of the Compiler namespace

### DIFF
--- a/Compiler/functions.php
+++ b/Compiler/functions.php
@@ -26,11 +26,12 @@ namespace Tale\Jade\Compiler {
          */
         function build_value($value, $quoteStyle, $escaped)
         {
-            if (method_exists($value, '__toString'))
-                return $quoteStyle.(string)$value.$quoteStyle;
-
-            if (is_object($value))
-                $value = (array)$value;
+            if (is_object($value)) {
+                if (method_exists($value, '__toString'))
+                    return $quoteStyle.(string)$value.$quoteStyle;
+                else
+                    $value = (array)$value;
+            }
 
             return $quoteStyle.($escaped ? htmlentities(is_array($value) ? flatten($value, '') : $value, \ENT_QUOTES) : ((string)$value)).$quoteStyle;
         }


### PR DESCRIPTION
Some projects, for example the Yii autoloader, try to automatically load any
string that is inserted as the first argument of `method_exists`. This was a
problem in `\Tale\Jade\Compiler\build_value`, which also tried finding the `__toString` method for
variables that already were strings. This commit fixes that problem by always
checking beforehand if a variable is an object.
